### PR TITLE
skip project build during release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.609</version>
+    <version>1.610-SNAPSHOT</version>
   </parent>
   <artifactId>release</artifactId>
   <packaging>hpi</packaging>

--- a/src/main/java/hudson/plugins/release/ReleaseWrapper.java
+++ b/src/main/java/hudson/plugins/release/ReleaseWrapper.java
@@ -110,6 +110,7 @@ public class ReleaseWrapper extends BuildWrapper implements MatrixAggregatable {
     private String releaseVersionTemplate;
     private boolean doNotKeepLog;
     private boolean overrideBuildParameters;
+    private boolean skipProjectBuild;
     private List<ParameterDefinition> parameterDefinitions = new ArrayList<ParameterDefinition>();
     private List<BuildStep> preBuildSteps = new ArrayList<BuildStep>();
     private List<BuildStep> postBuildSteps = new ArrayList<BuildStep>();
@@ -192,6 +193,14 @@ public class ReleaseWrapper extends BuildWrapper implements MatrixAggregatable {
     
     public void setOverrideBuildParameters(boolean overrideBuildParameters) {
         this.overrideBuildParameters = overrideBuildParameters;
+    }
+    
+    public boolean isSkipProjectBuild() {
+        return skipProjectBuild;
+    }
+    
+    public void setSkipProjectBuild(boolean skipProjectBuild) {
+        this.skipProjectBuild = skipProjectBuild;
     }
 
     public List<ParameterDefinition> getParameterDefinitions() {
@@ -341,6 +350,12 @@ public class ReleaseWrapper extends BuildWrapper implements MatrixAggregatable {
         
         // return environment
         return new Environment() {
+            
+            @Override
+            public boolean skipProjectBuilders() {
+
+                return skipProjectBuild;
+            }
         	
             @Override
             public boolean tearDown(AbstractBuild build, BuildListener listener) throws IOException,
@@ -457,6 +472,7 @@ public class ReleaseWrapper extends BuildWrapper implements MatrixAggregatable {
             instance.releaseVersionTemplate = formData.getString("releaseVersionTemplate");
             instance.doNotKeepLog = formData.getBoolean("doNotKeepLog");
             instance.overrideBuildParameters = formData.getBoolean("overrideBuildParameters");
+            instance.skipProjectBuild = formData.getBoolean("skipProjectBuild");
             instance.parameterDefinitions = Descriptor.newInstancesFromHeteroList(req, formData, "parameters", ParameterDefinition.all());
             instance.preBuildSteps = Descriptor.newInstancesFromHeteroList(req, formData, "preBuildSteps", getSteps());
             instance.preMatrixBuildSteps = Descriptor.newInstancesFromHeteroList(req, formData, "preMatrixBuildSteps", getSteps());

--- a/src/main/resources/hudson/plugins/release/ReleaseWrapper/config.jelly
+++ b/src/main/resources/hudson/plugins/release/ReleaseWrapper/config.jelly
@@ -43,6 +43,10 @@
     <f:entry title="${%Override build parameters}" help="/plugin/release/help-overrideBuildParameters.html">
         <f:checkbox name="overrideBuildParameters" field="overrideBuildParameters" />
     </f:entry>
+    
+    <f:entry title="${%Skip project build}" help="/plugin/release/help-skipProjectBuild.html">
+        <f:checkbox name="skipProjectBuild" field="skipProjectBuild" />
+    </f:entry>
 
 	<f:block>
 

--- a/src/main/webapp/help-skipProjectBuild.html
+++ b/src/main/webapp/help-skipProjectBuild.html
@@ -1,0 +1,4 @@
+<div>
+    Check if you want to skip the default project build, when running a release.
+    If unchecked, the default project build will take place after the release build.
+</div>


### PR DESCRIPTION
This is an enhancement to the current plugin. The changes enables the release plugin to notify the Jenkins core builder to skip the default project build after the release. 
A pull request is made to Jenkins core code source to get this enhancement working here is the link :-https://github.com/jenkinsci/jenkins/pull/1657

The pull request addresses the following issues on Jenkins issue board:- 
https://issues.jenkins-ci.org/browse/JENKINS-11120
https://issues.jenkins-ci.org/browse/JENKINS-27723 
